### PR TITLE
Add an option to provide output filename.

### DIFF
--- a/pdf2image/pdf2image.py
+++ b/pdf2image/pdf2image.py
@@ -24,7 +24,7 @@ from .exceptions import (
     PDFSyntaxError
 )
 
-def convert_from_path(pdf_path, dpi=200, output_folder=None, first_page=None, last_page=None, fmt='ppm', thread_count=1, userpw=None, use_cropbox=False, strict=False, transparent=False, out_file=None):
+def convert_from_path(pdf_path, dpi=200, output_folder=None, first_page=None, last_page=None, fmt='ppm', thread_count=1, userpw=None, use_cropbox=False, strict=False, transparent=False, output_file=str(uuid.uuid4())):
     """
         Description: Convert PDF to Image will throw whenever one of the condition is reached
         Parameters:
@@ -73,12 +73,10 @@ def convert_from_path(pdf_path, dpi=200, output_folder=None, first_page=None, la
     current_page = first_page
     processes = []
     for _ in range(thread_count):
-        # Get the filename of the output file.
-        out_file = pdf_path.rpartition('.')[0] if not out_file else out_file
         # Get the number of pages the thread will be processing
         thread_page_count = page_count // thread_count + int(reminder > 0)
         # Build the command accordingly
-        args = _build_command(['-r', str(dpi), pdf_path], output_folder, current_page, current_page + thread_page_count - 1, parsed_fmt, out_file, userpw, use_cropbox, transparent)
+        args = _build_command(['-r', str(dpi), pdf_path], output_folder, current_page, current_page + thread_page_count - 1, parsed_fmt, output_file, userpw, use_cropbox, transparent)
 
         if use_pdfcairo:
             args = ['pdftocairo'] + args
@@ -89,7 +87,7 @@ def convert_from_path(pdf_path, dpi=200, output_folder=None, first_page=None, la
         current_page = current_page + thread_page_count
         reminder -= int(reminder > 0)
         # Spawn the process and save its uuid
-        processes.append((out_file, Popen(args, stdout=PIPE, stderr=PIPE)))
+        processes.append((output_file, Popen(args, stdout=PIPE, stderr=PIPE)))
 
     images = []
 
@@ -109,7 +107,7 @@ def convert_from_path(pdf_path, dpi=200, output_folder=None, first_page=None, la
 
     return images
 
-def convert_from_bytes(pdf_file, dpi=200, output_folder=None, first_page=None, last_page=None, fmt='ppm', thread_count=1, userpw=None, use_cropbox=False, strict=False, transparent=False, out_file=None):
+def convert_from_bytes(pdf_file, dpi=200, output_folder=None, first_page=None, last_page=None, fmt='ppm', thread_count=1, userpw=None, use_cropbox=False, strict=False, transparent=False, output_file=str(uuid.uuid4())):
     """
         Description: Convert PDF to Image will throw whenever one of the condition is reached
         Parameters:
@@ -131,11 +129,11 @@ def convert_from_bytes(pdf_file, dpi=200, output_folder=None, first_page=None, l
         with open(temp_filename, 'wb') as f:
             f.write(pdf_file)
             f.flush()
-            return convert_from_path(f.name, dpi=dpi, output_folder=output_folder, first_page=first_page, last_page=last_page, fmt=fmt, thread_count=thread_count, userpw=userpw, use_cropbox=use_cropbox, strict=strict, transparent=transparent, out_file=out_file)
+            return convert_from_path(f.name, dpi=dpi, output_folder=output_folder, first_page=first_page, last_page=last_page, fmt=fmt, thread_count=thread_count, userpw=userpw, use_cropbox=use_cropbox, strict=strict, transparent=transparent, output_file=output_file)
     finally:
         os.remove(temp_filename)
 
-def _build_command(args, output_folder, first_page, last_page, fmt, out_file, userpw, use_cropbox, transparent):
+def _build_command(args, output_folder, first_page, last_page, fmt, output_file, userpw, use_cropbox, transparent):
     if use_cropbox:
         args.append('-cropbox')
 
@@ -152,7 +150,7 @@ def _build_command(args, output_folder, first_page, last_page, fmt, out_file, us
         args.append('-' + fmt)
 
     if output_folder is not None:
-        args.append(os.path.join(output_folder, out_file))
+        args.append(os.path.join(output_folder, output_file))
 
     if userpw is not None:
         args.extend(['-upw', userpw])
@@ -189,10 +187,10 @@ def _page_count(pdf_path, userpw=None):
     except:
         raise PDFPageCountError('Unable to get page count. %s' % err.decode("utf8", "ignore"))
 
-def _load_from_output_folder(output_folder, out_file, in_memory=False):
+def _load_from_output_folder(output_folder, output_file, in_memory=False):
     images = []
     for f in sorted(os.listdir(output_folder)):
-        if out_file in f:
+        if output_file in f:
             images.append(Image.open(os.path.join(output_folder, f)))
             if in_memory:
                 images[-1].load()

--- a/pdf2image/pdf2image.py
+++ b/pdf2image/pdf2image.py
@@ -78,7 +78,7 @@ def convert_from_path(pdf_path, dpi=200, output_folder=None, first_page=None, la
         # Get the number of pages the thread will be processing
         thread_page_count = page_count // thread_count + int(reminder > 0)
         # Build the command accordingly
-        args = _build_command(['-r', str(dpi), pdf_path], output_folder, current_page, current_page + thread_page_count - 1, parsed_fmt, uid, userpw, use_cropbox, transparent)
+        args = _build_command(['-r', str(dpi), pdf_path], output_folder, current_page, current_page + thread_page_count - 1, parsed_fmt, out_file, userpw, use_cropbox, transparent)
 
         if use_pdfcairo:
             args = ['pdftocairo'] + args


### PR DESCRIPTION
Right now, there's no option to provide an output filename to the command.
This Pull Request adds an option to do so.
In case, there's no filename provided, it takes the filename of the input file. This will be useful in case there's a need to convert many files and to trace back to the pdf from which the image was extracted.