### PR TITLE
Handle first_page greater than last_page

### DIFF
--- a/pdf2image/pdf2image.py
+++ b/pdf2image/pdf2image.py
@@ -67,6 +67,9 @@ def convert_from_path(pdf_path, dpi=200, output_folder=None, first_page=None, la
     if last_page is None or last_page > page_count:
         last_page = page_count
 
+    if first_page > last_page:
+        return []
+
     auto_temp_dir = False
     if output_folder is None and use_pdfcairo:
         auto_temp_dir = True

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 setup(
     name='pdf2image',
 
-    version='1.5.3',
+    version='1.5.4',
 
     description='A wrapper around the pdftoppm and pdftocairo command line tools to convert PDF to a PIL Image list.',
     long_description=long_description,

--- a/tests.py
+++ b/tests.py
@@ -721,5 +721,23 @@ class PDFConversionMethods(unittest.TestCase):
         [im.close() for im in images_from_path]
         print('test_conversion_from_path_using_poppler_path_with_trailing_slash: {} sec'.format((time.time() - start_time)))
 
+    ## Test first page greater or equal to last_page
+
+    @profile
+    @unittest.skipIf(not POPPLER_INSTALLED, "Poppler is not installed!")
+    def test_conversion_from_path_14_first_page_1_last_page_1(self):
+        start_time = time.time()
+        images_from_path = convert_from_path('./tests/test_14.pdf', first_page=1, last_page=1)
+        self.assertTrue(len(images_from_path) == 1)
+        print('test_conversion_from_path_14: {} sec'.format((time.time() - start_time) / 14.))
+
+    @profile
+    @unittest.skipIf(not POPPLER_INSTALLED, "Poppler is not installed!")
+    def test_conversion_from_path_14_first_page_12_last_page_1(self):
+        start_time = time.time()
+        images_from_path = convert_from_path('./tests/test_14.pdf', first_page=12, last_page=1)
+        self.assertTrue(len(images_from_path) == 0)
+        print('test_conversion_from_path_14: {} sec'.format((time.time() - start_time) / 14.))
+
 if __name__=='__main__':
     unittest.main()


### PR DESCRIPTION
This is done to emulate Python slices where

```py
a = [0, 1, 2]
a[2:0]
# []
```

Due to how `pdftoppm` and `pdftocairo` work, `first_page=1` with `last_page=1` will still return the first page. Even though in Python it would return an empty list.

Fixes #65 