### PR TITLE
changed how _page_count handles encoding from Popen output

### DIFF
--- a/pdf2image/pdf2image.py
+++ b/pdf2image/pdf2image.py
@@ -231,7 +231,7 @@ def _page_count(pdf_path, userpw=None, poppler_path=None):
         # This will throw if we are unable to get page count
         return int(re.search(r'Pages:\s+(\d+)', out).group(1))
     except:
-        raise PDFPageCountError('Unable to get page count. %s' % out)
+        raise PDFPageCountError('Unable to get page count. %s' % err)
 
 def _load_from_output_folder(output_folder, output_file, in_memory=False):
     images = []

--- a/pdf2image/pdf2image.py
+++ b/pdf2image/pdf2image.py
@@ -221,7 +221,7 @@ def _page_count(pdf_path, userpw=None, poppler_path=None):
         env = os.environ.copy()
         if poppler_path is not None:
             env["LD_LIBRARY_PATH"] = poppler_path + ":" + env.get("LD_LIBRARY_PATH", "")
-        proc = Popen(command, env=env, stdout=PIPE, stderr=PIPE)
+        proc = Popen(command, env=env, stdout=PIPE, stderr=PIPE, universal_newlines=True)
 
         out, err = proc.communicate()
     except:
@@ -229,10 +229,9 @@ def _page_count(pdf_path, userpw=None, poppler_path=None):
 
     try:
         # This will throw if we are unable to get page count
-        return int(re.search(r'Pages:\s+(\d+)', out.decode("utf8", "ignore")).group(1))
+        return int(re.search(r'Pages:\s+(\d+)', out).group(1))
     except:
-        raise PDFPageCountError('Unable to get page count. %s' % err.decode("utf8", "ignore"))
-
+        raise PDFPageCountError('Unable to get page count. %s' % out)
 
 def _load_from_output_folder(output_folder, output_file, in_memory=False):
     images = []


### PR DESCRIPTION
At my company we are using this library to process a huge amount of pdf files in batch processes and we notice that from time to time it failed to get the page count from some files By looking to your code i notice the way you are decoding outputs from bash commands, in my experience that can cause issues so this PR is implementing a way we use on some of our own libraries some of them already in production.

the only change is to pass "universal_newlines=True" as a parameter to Popen which according to [documentation](https://docs.python.org/3/library/subprocess.html) it transforms the output streams to text.

>Popen.stdout
If the stdout argument was PIPE, this attribute is a readable stream object as returned by open(). Reading from the stream provides output from the child process. If the encoding or errors arguments were specified or the universal_newlines argument was True, the stream is a text stream, otherwise it is a byte stream. If the stdout argument was not PIPE, this attribute is None.

And therefore removing the requirement to decode the out and err which as i mention its generating problems at least in our case. 

Sadly i can't provide the pdf so testing this might be tricky, but i hope it helps if somebody else is encountering the same issue