### PR TITLE
Add single_file parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,16 @@ with tempfile.TemporaryDirectory() as path:
 
 Here are the definitions:
 
-`convert_from_path(pdf_path, dpi=200, output_folder=None, first_page=None, last_page=None, fmt='ppm', thread_count=1, userpw=None, use_cropbox=False, strict=False, transparent=False, poppler_path=None)`
+`
+convert_from_path(pdf_path, dpi=200, output_folder=None, first_page=None, last_page=None, fmt='ppm', thread_count=1, userpw=None, use_cropbox=False, strict=False, transparent=False, single_file=False, output_file=str(uuid.uuid4()), poppler_path=None)
+`
 
-`convert_from_bytes(pdf_file, dpi=200, output_folder=None, first_page=None, last_page=None, fmt='ppm', thread_count=1, userpw=None, use_cropbox=False, strict=False, transparent=False, poppler_path=None)`
+`
+convert_from_bytes(pdf_file, dpi=200, output_folder=None, first_page=None, last_page=None, fmt='ppm', thread_count=1, userpw=None, use_cropbox=False, strict=False, transparent=False, single_file=False, output_file=str(uuid.uuid4()), poppler_path=None)
+`
 
 ## What's new?
+- `single_file` parameter allows you to convert the first PDF page only, without adding digits at the end of the `output_file` 
 - Allow the user to specify poppler's installation path with `poppler_path`
 - Fixed a bug where PNGs buffer with a non-terminating I-E-N-D sequence would throw an exception   
 - Fixed a bug that left open file descriptors when using `convert_from_bytes()` (Thank you @FabianUken)
@@ -74,7 +79,6 @@ Here are the definitions:
 - `transparent` parameter allows you to generate images with no background instead of the usual white one (You need pdftocairo for this)
 - `strict` parameter allows you to catch pdftoppm syntax error with a custom type `PDFSyntaxError`
 - `use_cropbox` parameter allows you to use the crop box instead of the media box when converting (`-cropbox` in pdftoppm's CLI)
-- `userpw` parameter allows you to set a password to unlock the converted PDF (`-upw` in pdftoppm's CLI)
 
 ## Performance tips
 

--- a/tests.py
+++ b/tests.py
@@ -739,5 +739,41 @@ class PDFConversionMethods(unittest.TestCase):
         self.assertTrue(len(images_from_path) == 0)
         print('test_conversion_from_path_14: {} sec'.format((time.time() - start_time) / 14.))
 
+    ## Test singlefile
+
+    @profile
+    @unittest.skipIf(not POPPLER_INSTALLED, "Poppler is not installed!")
+    def test_conversion_from_bytes_using_dir_single_file(self):
+        start_time = time.time()
+        with TemporaryDirectory() as path:
+            with open('./tests/test.pdf', 'rb') as pdf_file:
+                images_from_bytes = convert_from_bytes(pdf_file.read(), output_folder=path, output_file='test', single_file=True)
+                self.assertTrue(len(images_from_bytes) == 1)
+                self.assertTrue(images_from_bytes[0].filename == os.path.join(path, 'test.ppm'))
+                [im.close() for im in images_from_bytes]
+        print('test_conversion_from_bytes_using_dir_single_file: {} sec'.format(time.time() - start_time))
+
+    @profile
+    @unittest.skipIf(not POPPLER_INSTALLED, "Poppler is not installed!")
+    def test_conversion_from_path_using_dir_single_file(self):
+        start_time = time.time()
+        with TemporaryDirectory() as path:
+            images_from_path = convert_from_path('./tests/test.pdf', output_folder=path, output_file='test', single_file=True)
+            self.assertTrue(len(images_from_path) == 1)
+            self.assertTrue(images_from_path[0].filename == os.path.join(path, 'test.ppm'))
+            [im.close() for im in images_from_path]
+        print('test_conversion_from_path_using_dir_single_file: {} sec'.format(time.time() - start_time))
+
+    @profile
+    @unittest.skipIf(not POPPLER_INSTALLED, "Poppler is not installed!")
+    def test_conversion_from_path_using_dir_14_single_file(self):
+        start_time = time.time()
+        with TemporaryDirectory() as path:
+            images_from_path = convert_from_path('./tests/test_14.pdf', output_folder=path, output_file='test', single_file=True)
+            self.assertTrue(len(images_from_path) == 1)
+            self.assertTrue(images_from_path[0].filename == os.path.join(path, 'test.ppm'))
+            [im.close() for im in images_from_path]
+        print('test_conversion_from_path_using_dir_14_single_file: {} sec'.format((time.time() - start_time) / 14.))
+
 if __name__=='__main__':
     unittest.main()


### PR DESCRIPTION
Add a `single_file=False` optional parameter for `convert_from_path` and `convert_from_bytes`. It uses the `-singlefile` argument for `pdftoppm` and `pdftocairo`.

```
-singlefile              : write only the first page and do not add digits
```

Fixes: #71 