### PR TITLE
Prevent wrong filename matching

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -739,5 +739,41 @@ class PDFConversionMethods(unittest.TestCase):
         self.assertTrue(len(images_from_path) == 0)
         print('test_conversion_from_path_14: {} sec'.format((time.time() - start_time) / 14.))
 
+    ## Test singlefile
+
+    @profile
+    @unittest.skipIf(not POPPLER_INSTALLED, "Poppler is not installed!")
+    def test_conversion_from_bytes_using_dir_single_file(self):
+        start_time = time.time()
+        with TemporaryDirectory() as path:
+            with open('./tests/test.pdf', 'rb') as pdf_file:
+                images_from_bytes = convert_from_bytes(pdf_file.read(), output_folder=path, output_file='test', single_file=True)
+                self.assertTrue(len(images_from_bytes) == 1)
+                self.assertTrue(images_from_bytes[0].filename == os.path.join(path, 'test.ppm'))
+                [im.close() for im in images_from_bytes]
+        print('test_conversion_from_bytes_using_dir_single_file: {} sec'.format(time.time() - start_time))
+
+    @profile
+    @unittest.skipIf(not POPPLER_INSTALLED, "Poppler is not installed!")
+    def test_conversion_from_path_using_dir_single_file(self):
+        start_time = time.time()
+        with TemporaryDirectory() as path:
+            images_from_path = convert_from_path('./tests/test.pdf', output_folder=path, output_file='test', single_file=True)
+            self.assertTrue(len(images_from_path) == 1)
+            self.assertTrue(images_from_path[0].filename == os.path.join(path, 'test.ppm'))
+            [im.close() for im in images_from_path]
+        print('test_conversion_from_path_using_dir_single_file: {} sec'.format(time.time() - start_time))
+
+    @profile
+    @unittest.skipIf(not POPPLER_INSTALLED, "Poppler is not installed!")
+    def test_conversion_from_path_using_dir_14_single_file(self):
+        start_time = time.time()
+        with TemporaryDirectory() as path:
+            images_from_path = convert_from_path('./tests/test_14.pdf', output_folder=path, output_file='test', single_file=True)
+            self.assertTrue(len(images_from_path) == 1)
+            self.assertTrue(images_from_path[0].filename == os.path.join(path, 'test.ppm'))
+            [im.close() for im in images_from_path]
+        print('test_conversion_from_path_using_dir_14_single_file: {} sec'.format((time.time() - start_time) / 14.))
+
 if __name__=='__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -785,7 +785,7 @@ class PDFConversionMethods(unittest.TestCase):
             shutil.copyfile('./tests/test.pdf', os.path.join(path, 'test.pdf'))
             images_from_path = convert_from_path('./tests/test.pdf', output_folder=path, output_file='test')
             self.assertTrue(len(images_from_path) == 1)
-            self.assertTrue(images_from_path[0].filename == os.path.join(path, 'test.ppm'))
+            self.assertTrue(images_from_path[0].filename == os.path.join(path, 'test-1.ppm'))
             [im.close() for im in images_from_path]
         print('test_conversion_from_path_using_dir_single_file: {} sec'.format(time.time() - start_time))
 

--- a/tests.py
+++ b/tests.py
@@ -775,5 +775,19 @@ class PDFConversionMethods(unittest.TestCase):
             [im.close() for im in images_from_path]
         print('test_conversion_from_path_using_dir_14_single_file: {} sec'.format((time.time() - start_time) / 14.))
 
+    ## Test file with same name in directory
+
+    @profile
+    @unittest.skipIf(not POPPLER_INSTALLED, "Poppler is not installed!")
+    def test_conversion_from_path_using_dir_with_containing_file_with_same_name(self):
+        start_time = time.time()
+        with TemporaryDirectory() as path:
+            shutil.copyfile('./tests/test.pdf', os.path.join(path, 'test.pdf'))
+            images_from_path = convert_from_path('./tests/test.pdf', output_folder=path, output_file='test')
+            self.assertTrue(len(images_from_path) == 1)
+            self.assertTrue(images_from_path[0].filename == os.path.join(path, 'test.ppm'))
+            [im.close() for im in images_from_path]
+        print('test_conversion_from_path_using_dir_single_file: {} sec'.format(time.time() - start_time))
+
 if __name__=='__main__':
     unittest.main()


### PR DESCRIPTION
Instead of simply looking for the `output_file` string in the filename, use `.startswith()`. Also match the extension.

Fixes: #69 