### PR TITLE
Add recognition of pathlike objects as arguments

### DIFF
--- a/pdf2image/pdf2image.py
+++ b/pdf2image/pdf2image.py
@@ -207,16 +207,6 @@ def convert_from_bytes(
             grayscale -> Output grayscale image(s)
     """
 
-    # We make sure that if passed arguments are Path objects, they're converted to strings
-    if isinstance(pdf_file, pathlib.PurePath):
-        pdf_file = pdf_file.as_posix()
-
-    if isinstance(output_folder, pathlib.PurePath):
-        output_folder = output_folder.as_posix()
-
-    if isinstance(poppler_path, pathlib.PurePath):
-        poppler_path = poppler_path.as_posix()
-
     fh, temp_filename = tempfile.mkstemp()
     try:
         with open(temp_filename, "wb") as f:

--- a/pdf2image/pdf2image.py
+++ b/pdf2image/pdf2image.py
@@ -9,6 +9,7 @@ import re
 import uuid
 import tempfile
 import shutil
+import pathlib
 
 from subprocess import Popen, PIPE
 from PIL import Image
@@ -61,6 +62,16 @@ def convert_from_path(
             poppler_path -> Path to look for poppler binaries
             grayscale -> Output grayscale image(s)
     """
+
+    # We make sure that if passed arguments are Path objects, they're converted to strings
+    if isinstance(pdf_path, pathlib.PurePath):
+        pdf_path = pdf_path.as_posix()
+
+    if isinstance(output_folder, pathlib.PurePath):
+        output_folder = output_folder.as_posix()
+
+    if isinstance(poppler_path, pathlib.PurePath):
+        poppler_path = poppler_path.as_posix()
 
     page_count = _page_count(pdf_path, userpw, poppler_path=poppler_path)
 
@@ -195,6 +206,16 @@ def convert_from_bytes(
             poppler_path -> Path to look for poppler binaries
             grayscale -> Output grayscale image(s)
     """
+
+    # We make sure that if passed arguments are Path objects, they're converted to strings
+    if isinstance(pdf_file, pathlib.PurePath):
+        pdf_file = pdf_file.as_posix()
+
+    if isinstance(output_folder, pathlib.PurePath):
+        output_folder = output_folder.as_posix()
+
+    if isinstance(poppler_path, pathlib.PurePath):
+        poppler_path = poppler_path.as_posix()
 
     fh, temp_filename = tempfile.mkstemp()
     try:


### PR DESCRIPTION
As outlined in #87, passing Path objects as arguments breaks convert_from_path and raises a PDFInfoNotInstalledError exception, which is inconvenient, confusing and frustrating at the same time.

This PR adds logic for handling Pathlike objects as arguments, where appropriate.