### PR TITLE
Change os.errno into more compliant imported errno

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import errno
 import tempfile
 import unittest
 import time
@@ -43,7 +44,7 @@ try:
     )
     POPPLER_INSTALLED = True
 except OSError as e:
-    if e.errno == os.errno.ENOENT:
+    if e.errno == errno.ENOENT:
         POPPLER_INSTALLED = False
 
 


### PR DESCRIPTION
The use of os.errno is considered bad practice, while importing errno explicitly and using it is better.
Use of os.errno is not supported in 3.6 and onwards, but use of errno works fine, just as it does in older versions as well.

This PR aims to make the code more compliant and future-proof.

Source: https://bugs.python.org/issue33666