### PR TITLE
Implement generator support for output filenames

### DIFF
--- a/pdf2image/generators.py
+++ b/pdf2image/generators.py
@@ -1,0 +1,17 @@
+"""
+    pdf2image filename generators
+"""
+
+import uuid
+
+def uuid_generator():
+    "Returns a UUID4"
+    while True:
+        yield str(uuid.uuid4())
+
+def counter_generator(prefix="", suffix="", padding_goal=4):
+    "Returns a joined prefix, iteration number, and suffix"
+    i = 0
+    while True:
+        i += 1
+        yield str(prefix) + str(i).zfill(padding_goal) + str(suffix)

--- a/tests.py
+++ b/tests.py
@@ -529,6 +529,7 @@ class PDFConversionMethods(unittest.TestCase):
             "./tests/test.pdf", output_folder="./tests/"
         )
         self.assertTrue(len(images_from_path) == 1)
+        [im.close() for im in images_from_path]
         [os.remove(im.filename) for im in images_from_path]
         print(
             "test_non_empty_output_folder: {} sec".format(
@@ -1174,7 +1175,7 @@ class PDFConversionMethods(unittest.TestCase):
             )
             self.assertTrue(len(images_from_path) == 1)
             self.assertTrue(
-                images_from_path[0].filename == os.path.join(path, "test-1.ppm")
+                images_from_path[0].filename == os.path.join(path, "test0001-1.ppm")
             )
             [im.close() for im in images_from_path]
         print(


### PR DESCRIPTION
Generators in Python are special objects that can be iterated over, and with each iteration they'll yield a new output depending on what they are.

By separating the logic of creating incremental filenames away from the parts that create files, and by allowing user to supply a custom generator of their own we allow the flexibility to explode.

Supplying anything else that isn't a generator is still accounted for legacy purposes.