### PR TITLE
Add paths_only option

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -4,7 +4,7 @@
 
 ### convert_from_path & convert_from_bytes
 
-Converts a PDF into image(s) 
+Converts a PDF into image(s)
 
 ```py
 convert_from_path(
@@ -24,6 +24,7 @@ convert_from_path(
     poppler_path=None,
     grayscale=False,
     size=None,
+    paths_only=False,
 )
 
 convert_from_bytes(
@@ -43,6 +44,7 @@ convert_from_bytes(
     poppler_path=None,
     grayscale=False,
     size=None,
+    paths_only=False,
 )
 ```
 
@@ -112,7 +114,7 @@ Returns grayscale images
 
 **size**
 
-Size of output images, using `None` as any of the dimension will resize and preserve aspect ratio. 
+Size of output images, using `None` as any of the dimension will resize and preserve aspect ratio.
 
 Examples of valid sizes are:
 
@@ -121,6 +123,10 @@ Examples of valid sizes are:
 - `size=(500, 500)` will resize the image to 500x500 pixels, not preserving aspect ratio
 
 This behavior is derived directly from the `-scale-to`, `-scale-to-x`, and `-scale-to-y` parameters.
+
+**paths_only**
+
+A list of image paths rather than preloaded images are returned.
 
 ## Exceptions
 

--- a/pdf2image/pdf2image.py
+++ b/pdf2image/pdf2image.py
@@ -66,7 +66,7 @@ def convert_from_path(
             poppler_path -> Path to look for poppler binaries
             grayscale -> Output grayscale image(s)
             size -> Size of the resulting image(s), uses the Pillow (width, height) standard
-            paths_only -> Don't load image(s), return paths instead
+            paths_only -> Don't load image(s), return paths instead (requires output_folder)
     """
 
     # We make sure that if passed arguments are Path objects, they're converted to strings
@@ -221,7 +221,7 @@ def convert_from_bytes(
             poppler_path -> Path to look for poppler binaries
             grayscale -> Output grayscale image(s)
             size -> Size of the resulting image(s), uses the Pillow (width, height) standard
-            paths_only -> Don't load image(s), return paths instead
+            paths_only -> Don't load image(s), return paths instead (requires output_folder)
     """
 
     fh, temp_filename = tempfile.mkstemp()

--- a/pdf2image/pdf2image.py
+++ b/pdf2image/pdf2image.py
@@ -45,6 +45,7 @@ def convert_from_path(
     poppler_path=None,
     grayscale=False,
     size=None,
+    paths_only=False,
 ):
     """
         Description: Convert PDF to Image will throw whenever one of the condition is reached
@@ -65,6 +66,7 @@ def convert_from_path(
             poppler_path -> Path to look for poppler binaries
             grayscale -> Output grayscale image(s)
             size -> Size of the resulting image(s), uses the Pillow (width, height) standard
+            paths_only -> Don't load image(s), return paths instead
     """
 
     # We make sure that if passed arguments are Path objects, they're converted to strings
@@ -170,7 +172,7 @@ def convert_from_path(
 
         if output_folder is not None:
             images += _load_from_output_folder(
-                output_folder, uid, final_extension, in_memory=auto_temp_dir
+                output_folder, uid, final_extension, paths_only, in_memory=auto_temp_dir
             )
         else:
             images += parse_buffer_func(data)
@@ -198,6 +200,7 @@ def convert_from_bytes(
     poppler_path=None,
     grayscale=False,
     size=None,
+    paths_only=False,
 ):
     """
         Description: Convert PDF to Image will throw whenever one of the condition is reached
@@ -218,6 +221,7 @@ def convert_from_bytes(
             poppler_path -> Path to look for poppler binaries
             grayscale -> Output grayscale image(s)
             size -> Size of the resulting image(s), uses the Pillow (width, height) standard
+            paths_only -> Don't load image(s), return paths instead
     """
 
     fh, temp_filename = tempfile.mkstemp()
@@ -242,6 +246,7 @@ def convert_from_bytes(
                 poppler_path=poppler_path,
                 grayscale=grayscale,
                 size=size,
+                paths_only=paths_only,
             )
     finally:
         os.close(fh)
@@ -364,11 +369,16 @@ def _page_count(pdf_path, userpw=None, poppler_path=None):
         )
 
 
-def _load_from_output_folder(output_folder, output_file, ext, in_memory=False):
+def _load_from_output_folder(
+    output_folder, output_file, ext, paths_only, in_memory=False
+):
     images = []
     for f in sorted(os.listdir(output_folder)):
         if f.startswith(output_file) and f.split(".")[-1] == ext:
-            images.append(Image.open(os.path.join(output_folder, f)))
-            if in_memory:
-                images[-1].load()
+            if paths_only:
+                images.append(os.path.join(output_folder, f))
+            else:
+                images.append(Image.open(os.path.join(output_folder, f)))
+                if in_memory:
+                    images[-1].load()
     return images

--- a/tests.py
+++ b/tests.py
@@ -1331,5 +1331,19 @@ class PDFConversionMethods(unittest.TestCase):
         self.assertTrue(len(images_from_path) == 1)
         print("test_conversion_from_path_with_2d_tuple_size_with_None_width: {} sec".format(time.time() - start_time))
 
+    @profile
+    @unittest.skipIf(not POPPLER_INSTALLED, "Poppler is not installed!")
+    def test_conversion_from_path_using_dir_paths_only(self):
+        start_time = time.time()
+        with TemporaryDirectory() as path:
+            images_from_path = convert_from_path("./tests/test.pdf", output_folder=path, paths_only=True)
+            self.assertTrue(len(images_from_path) == 1)
+            self.assertTrue(type(images_from_path[0]) == str)
+        print(
+            "test_conversion_from_path_using_dir: {} sec".format(
+                time.time() - start_time
+            )
+        )
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I've had a few problems with memory/resources being used up rapidly when converting many PDFs, even when using a temporary folder (I reached the opened files limit then). Initially I thought the function returns a list of paths, and I was surprised to find that the images were preloaded, which I think may be unnecessary in some cases (it was in mine), so I added a quick option to only return the paths rather than load and return the images. I don't think it makes sense to use it in conjunction with the `in_memory` option so I've made them mutually exclusive (you cannot load images into memory if all you want is the paths).

Closes (a possible solution for) #80 and #31.

Thanks for this great little gem!