### PR TITLE
Add jpegopt

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -13,6 +13,7 @@ convert_from_path(
     output_folder=None,
     first_page=None,
     last_page=None,
+    jpegopt=None,
     fmt="ppm",
     thread_count=1,
     userpw=None,
@@ -34,6 +35,7 @@ convert_from_bytes(
     first_page=None,
     last_page=None,
     fmt="ppm",
+    jpegopt=None,
     thread_count=1,
     userpw=None,
     use_cropbox=False,
@@ -127,6 +129,12 @@ This behavior is derived directly from the `-scale-to`, `-scale-to-x`, and `-sca
 **paths_only**
 
 A list of image paths rather than preloaded images are returned.
+
+**jpegopt**
+
+Provide additional options for jpeg format conversions. Requires `fmt="jpeg"` and is provided as dict, with all
+optinal keywords:
+`jpegopt={"quality": 100, "optimize": True, "progressive": False}
 
 ## Exceptions
 

--- a/pdf2image/pdf2image.py
+++ b/pdf2image/pdf2image.py
@@ -35,6 +35,7 @@ def convert_from_path(
     first_page=None,
     last_page=None,
     fmt="ppm",
+    jpegopt=None,
     thread_count=1,
     userpw=None,
     use_cropbox=False,
@@ -56,6 +57,7 @@ def convert_from_path(
             first_page -> First page to process
             last_page -> Last page to process before stopping
             fmt -> Output image format
+            jpegopt -> jpeg options `quality`, `progressive`, and `optimize` (only for jpeg format)
             thread_count -> How many threads we are allowed to spawn for processing
             userpw -> PDF's password
             use_cropbox -> Use cropbox instead of mediabox
@@ -136,6 +138,7 @@ def convert_from_path(
             current_page,
             current_page + thread_page_count - 1,
             parsed_fmt,
+            jpegopt,
             thread_output_file,
             userpw,
             use_cropbox,
@@ -190,6 +193,7 @@ def convert_from_bytes(
     first_page=None,
     last_page=None,
     fmt="ppm",
+    jpegopt=None,
     thread_count=1,
     userpw=None,
     use_cropbox=False,
@@ -211,6 +215,7 @@ def convert_from_bytes(
             first_page -> First page to process
             last_page -> Last page to process before stopping
             fmt -> Output image format
+            jpegopt -> jpeg options `quality`, `progressive`, and `optimize` (only for jpeg format)
             thread_count -> How many threads we are allowed to spawn for processing
             userpw -> PDF's password
             use_cropbox -> Use cropbox instead of mediabox
@@ -236,6 +241,7 @@ def convert_from_bytes(
                 first_page=first_page,
                 last_page=last_page,
                 fmt=fmt,
+                jpegopt=jpegopt,
                 thread_count=thread_count,
                 userpw=userpw,
                 use_cropbox=use_cropbox,
@@ -259,6 +265,7 @@ def _build_command(
     first_page,
     last_page,
     fmt,
+    jpegopt,
     output_file,
     userpw,
     use_cropbox,
@@ -281,6 +288,9 @@ def _build_command(
 
     if fmt not in ["pgm", "ppm"]:
         args.append("-" + fmt)
+
+    if fmt in ["jpeg", "jpg"] and jpegopt:
+        args.extend(["-jpegopt", _parse_jpegopt(jpegopt)])
 
     if single_file:
         args.append("-singlefile")
@@ -329,6 +339,17 @@ def _parse_format(fmt, grayscale=False):
         return "pgm", "pgm", parse_buffer_to_pgm, False
     # Unable to parse the format so we'll use the default
     return "ppm", "ppm", parse_buffer_to_ppm, False
+
+
+def _parse_jpegopt(jpegopt):
+    parts = []
+    for k, v in jpegopt.items():
+        if v is True:
+            v = "y"
+        if v is False:
+            v = "n"
+        parts.append("{}={}".format(k, v))
+    return ",".join(parts)
 
 
 def _get_command_path(command, poppler_path=None):

--- a/tests.py
+++ b/tests.py
@@ -1271,6 +1271,28 @@ class PDFConversionMethods(unittest.TestCase):
             )
         )
 
+    ## Test jpegopt parameter
+
+    @profile
+    @unittest.skipIf(not POPPLER_INSTALLED, "Poppler is not installed!")
+    def test_conversion_from_path_with_quality(self):
+        start_time = time.time()
+        images_from_path = convert_from_path("./tests/test.pdf", fmt="jpeg", jpegopt={"quality": 100})
+        self.assertTrue(len(images_from_path) == 1)
+        print("test_conversion_from_path_with_int_size: {} sec".format(time.time() - start_time))
+
+
+    @profile
+    @unittest.skipIf(not POPPLER_INSTALLED, "Poppler is not installed!")
+    def test_conversion_from_path_with_quality(self):
+        start_time = time.time()
+        with open("./tests/test.pdf", "rb") as pdf_file:
+            images_from_bytes = convert_from_bytes(pdf_file.read(), fmt="jpg", jpegopt={"quality": 100})
+            self.assertTrue(len(images_from_bytes) == 1)
+        print("test_conversion_from_bytes: {} sec".format(time.time() - start_time))
+
+
+    @profile
     ## Test size parameter
 
     @profile


### PR DESCRIPTION
Adds the `jpegopt`parameters to `convert_from_path()` and `convert_from_bytes()`.
Requires `fmt="jpeg"` and is provided as dict such as:

```python
jpegopt: {"quality": 100, "optimize": True, "progressive": False}
```

Full example:
```python
pdf2image.convert_from_path(<path_to_pdf>, size=3500, fmt="jpeg", jpegopt={"quality":100, "optimize":True})
```

Tests not added yet.