### PR TITLE
Urgent fix generator Windows

### DIFF
--- a/pdf2image/generators.py
+++ b/pdf2image/generators.py
@@ -13,6 +13,9 @@ class ThreadSafeGenerator(object):
         self.gen = gen
         self.lock = threading.Lock()
 
+    def __iter__(self):
+        return self
+
     def __next__(self):
         with self.lock:
             return next(self.gen)

--- a/pdf2image/pdf2image.py
+++ b/pdf2image/pdf2image.py
@@ -13,7 +13,7 @@ import pathlib
 from subprocess import Popen, PIPE
 from PIL import Image
 
-from .generators import uuid_generator, counter_generator
+from .generators import uuid_generator, counter_generator, ThreadSafeGenerator
 
 from .parsers import (
     parse_buffer_to_pgm,
@@ -106,7 +106,8 @@ def convert_from_path(
         jpegopt = None
 
     # If output_file isn't a generator, it will be turned into one
-    if not isinstance(output_file, types.GeneratorType):
+    if (not isinstance(output_file, types.GeneratorType) and
+        not isinstance(output_file, ThreadSafeGenerator)):
         if single_file:
             output_file = iter([output_file])
         else:


### PR DESCRIPTION
Not too sure how to explain the bug itself, but it worked fine on Linux through luck and magic as the default generator was not actually a generator anymore so it should have blown up.

I will merge this fix as soon as the CI pass and create version 1.12.1.

I will also write a post-mortem because it seems to indicate that there are differences between platforms that I was not aware of.

Fixes: #127 