### PR TITLE
Highlight another way to use Poppler path on Win clearly

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A python (3.5+) module that wraps pdftoppm and pdftocairo to convert PDF to a PI
 
 ### Windows
 
-Windows users will have to install [poppler for Windows](http://blog.alivate.com.au/poppler-windows/), then add the `bin/` folder to [PATH](https://www.architectryan.com/2018/03/17/add-to-the-path-on-windows-10/).
+Windows users will have to install [poppler for Windows](http://blog.alivate.com.au/poppler-windows/), then add the `bin/` folder to [PATH](https://www.architectryan.com/2018/03/17/add-to-the-path-on-windows-10/) or use poppler_path = r"C:\path\to\poppler-xx\bin" as an argument in ```convert_from_path``` function call.
 
 ### Mac
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A python (3.5+) module that wraps pdftoppm and pdftocairo to convert PDF to a PI
 
 ### Windows
 
-Windows users will have to install [poppler for Windows](http://blog.alivate.com.au/poppler-windows/), then add the `bin/` folder to [PATH](https://www.architectryan.com/2018/03/17/add-to-the-path-on-windows-10/) or use poppler_path = r"C:\path\to\poppler-xx\bin" as an argument in ```convert_from_path``` function call.
+Windows users will have to install [poppler for Windows](http://blog.alivate.com.au/poppler-windows/), then add the `bin/` folder to [PATH](https://www.architectryan.com/2018/03/17/add-to-the-path-on-windows-10/) or use `poppler_path = r"C:\path\to\poppler-xx\bin" as an argument` in `convert_from_path`.
 
 ### Mac
 


### PR DESCRIPTION
For windows users without admin rights, adding poppler to PATH is not a feasible option. However using the poppler_path argument is a simpler method for users to get started easily & should be shown in the README steps.