### PR TITLE
Handle rawdates

### DIFF
--- a/pdf2image/pdf2image.py
+++ b/pdf2image/pdf2image.py
@@ -406,12 +406,15 @@ def _get_poppler_version(command, poppler_path=None):
         return 17
 
 
-def pdfinfo_from_path(pdf_path, userpw=None, poppler_path=None):
+def pdfinfo_from_path(pdf_path, userpw=None, poppler_path=None, rawdates=False):
     try:
         command = [_get_command_path("pdfinfo", poppler_path), pdf_path]
 
         if userpw is not None:
             command.extend(["-upw", userpw])
+
+        if rawdates:
+            command.extend(["-rawdates"])
 
         # Add poppler path to LD_LIBRARY_PATH
         env = os.environ.copy()
@@ -447,13 +450,13 @@ def pdfinfo_from_path(pdf_path, userpw=None, poppler_path=None):
         )
 
 
-def pdfinfo_from_bytes(pdf_file):
+def pdfinfo_from_bytes(pdf_file, userpw=None, rawdates=False):
     fh, temp_filename = tempfile.mkstemp()
     try:
         with open(temp_filename, "wb") as f:
             f.write(pdf_file)
             f.flush()
-        return pdfinfo_from_path(temp_filename)
+        return pdfinfo_from_path(temp_filename, userpw=userpw, rawdates=rawdates)
     finally:
         os.close(fh)
         os.remove(temp_filename)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="pdf2image",
-    version="1.13.1",
+    version="1.14.0",
     description="A wrapper around the pdftoppm and pdftocairo command line tools to convert PDF to a PIL Image list.",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Hi,

The purpose of the this PR is to add the ability to retrieve the PDF creation date as a raw string instead of the formatted string returned by default by `pdfinfo`.

I simply added the `-rawdates` option to `pdfinfo_from_bytes` and `pdfinfo_from_path`. I also added the missing `userpw` option to `pdfinfo_from_bytes`. The reason I wanted the date as a raw string is because of the timezone. This information is lost when the timestamp is formatted.

Hope that helps. Thank you for the repo!
Best,
Louis