### PR TITLE
Add test for timeout functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Use the [mattermost chat](https://mattermost.belval.org/signup_user_complete/?id
 
 ## What's new?
 
+- Add `timeout` parameter which raises `PDFPopplerTimeoutError` after the given number of seconds.
 - Add `use_pdftocairo` parameter which forces `pdf2image` to use `pdftocairo`. Should improve performance.
 - Fixed a bug where using `pdf2image` with multiple threads (but not multiple processes) would cause and exception
 - `jpegopt` parameter allows for tuning of the output JPEG when using `fmt="jpeg"` (`-jpegopt` in pdftoppm CLI) (Thank you @abieler)
@@ -84,7 +85,6 @@ Use the [mattermost chat](https://mattermost.belval.org/signup_user_complete/?id
 - `grayscale` parameter allows you to convert images to grayscale (`-gray` in pdftoppm CLI)
 - `single_file` parameter allows you to convert the first PDF page only, without adding digits at the end of the `output_file`
 - Allow the user to specify poppler's installation path with `poppler_path`
-- Fixed a bug where PNGs buffer with a non-terminating I-E-N-D sequence would throw an exception
 
 ## Performance tips
 

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ with tempfile.TemporaryDirectory() as path:
 
 Here are the definitions:
 
-`convert_from_path(pdf_path, dpi=200, output_folder=None, first_page=None, last_page=None, fmt='ppm', jpegopt=None, thread_count=1, userpw=None, use_cropbox=False, strict=False, transparent=False, single_file=False, output_file=str(uuid.uuid4()), poppler_path=None, grayscale=False, size=None, paths_only=False, use_pdftocairo=False)`
+`convert_from_path(pdf_path, dpi=200, output_folder=None, first_page=None, last_page=None, fmt='ppm', jpegopt=None, thread_count=1, userpw=None, use_cropbox=False, strict=False, transparent=False, single_file=False, output_file=str(uuid.uuid4()), poppler_path=None, grayscale=False, size=None, paths_only=False, use_pdftocairo=False, timeout=600)`
 
-`convert_from_bytes(pdf_file, dpi=200, output_folder=None, first_page=None, last_page=None, fmt='ppm', jpegopt=None, thread_count=1, userpw=None, use_cropbox=False, strict=False, transparent=False, single_file=False, output_file=str(uuid.uuid4()), poppler_path=None, grayscale=False, size=None, paths_only=False, use_pdftocairo=False)`
+`convert_from_bytes(pdf_file, dpi=200, output_folder=None, first_page=None, last_page=None, fmt='ppm', jpegopt=None, thread_count=1, userpw=None, use_cropbox=False, strict=False, transparent=False, single_file=False, output_file=str(uuid.uuid4()), poppler_path=None, grayscale=False, size=None, paths_only=False, use_pdftocairo=False, timeout=600)`
 
 ## Need help?
 

--- a/pdf2image/pdf2image.py
+++ b/pdf2image/pdf2image.py
@@ -78,6 +78,7 @@ def convert_from_path(
             size -> Size of the resulting image(s), uses the Pillow (width, height) standard
             paths_only -> Don't load image(s), return paths instead (requires output_folder)
             use_pdftocairo -> Use pdftocairo instead of pdftoppm, may help performance
+            timeout -> Raise PDFPopplerTimeoutError after the given time
     """
 
     if use_pdftocairo and fmt == "ppm":
@@ -234,6 +235,7 @@ def convert_from_bytes(
     size=None,
     paths_only=False,
     use_pdftocairo=False,
+    timeout=600,
 ):
     """
         Description: Convert PDF to Image will throw whenever one of the condition is reached
@@ -284,6 +286,7 @@ def convert_from_bytes(
                 size=size,
                 paths_only=paths_only,
                 use_pdftocairo=use_pdftocairo,
+                timeout=timeout,
             )
     finally:
         os.close(fh)
@@ -418,7 +421,9 @@ def _get_poppler_version(command, poppler_path=None, timeout=60):
         return 17
 
 
-def pdfinfo_from_path(pdf_path, userpw=None, poppler_path=None, rawdates=False, timeout=60):
+def pdfinfo_from_path(
+    pdf_path, userpw=None, poppler_path=None, rawdates=False, timeout=60
+):
     try:
         command = [_get_command_path("pdfinfo", poppler_path), pdf_path]
 
@@ -467,7 +472,9 @@ def pdfinfo_from_path(pdf_path, userpw=None, poppler_path=None, rawdates=False, 
         )
 
 
-def pdfinfo_from_bytes(pdf_file, userpw=None, rawdates=False):
+def pdfinfo_from_bytes(
+    pdf_file, userpw=None, poppler_path=None, rawdates=False, timeout=60
+):
     fh, temp_filename = tempfile.mkstemp()
     try:
         with open(temp_filename, "wb") as f:

--- a/tests.py
+++ b/tests.py
@@ -24,6 +24,7 @@ from pdf2image.exceptions import (
     PDFInfoNotInstalledError,
     PDFPageCountError,
     PDFSyntaxError,
+    PDFPopplerTimeoutError,
 )
 
 from functools import wraps
@@ -1622,6 +1623,22 @@ class PDFConversionMethods(unittest.TestCase):
         print(
             "test_pdfinfo_locked_pdf_with_userpw_only: {} sec".format(time.time() - start_time)
         )
+
+    @profile
+    @unittest.skipIf(not POPPLER_INSTALLED, "Poppler is not installed!")
+    def test_timeout_pdfinfo_from_path_241(self):
+        start_time = time.time()
+        with self.assertRaises(PDFPopplerTimeoutError):
+            info = pdfinfo_from_path("./tests/test_241.pdf", timeout=0.00001)
+        print("test_timeout_pdfinfo_from_path_241: {} sec".format(time.time() - start_time))
+
+    @profile
+    @unittest.skipIf(not POPPLER_INSTALLED, "Poppler is not installed!")
+    def test_timeout_convert_from_path_241(self):
+        start_time = time.time()
+        with self.assertRaises(PDFPopplerTimeoutError):
+            imgs = convert_from_path("./tests/test_241.pdf", timeout=1)
+        print("test_timeout_convert_from_path_241: {} sec".format(time.time() - start_time))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This is a complementary PR to #156 which adds tests and adds the parameter to the `from_bytes` versions of the functions.