### PR TITLE
Add tests to check same parameter count in from_path and from_bytes

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -1599,6 +1599,29 @@ class PDFConversionMethods(unittest.TestCase):
             )
         )
 
+    @profile
+    @unittest.skipIf(not POPPLER_INSTALLED, "Poppler is not installed!")
+    def test_pdfinfo_rawdates(self):
+        start_time = time.time()
+        info = pdfinfo_from_path("./tests/test.pdf", rawdates=True)
+        self.assertTrue("D:" in info["CreationDate"])
+        print(
+            "test_pdfinfo_rawdates: {} sec".format(time.time() - start_time)
+        )
+
+    @profile
+    @unittest.skipIf(not POPPLER_INSTALLED, "Poppler is not installed!")
+    def test_pdfinfo_locked_pdf_with_userpw_only(self):
+        start_time = time.time()
+        with TemporaryDirectory() as path:
+            with open("./tests/test_locked_user_only.pdf", "rb") as pdf_file:
+                info = pdfinfo_from_bytes(
+                    pdf_file.read(), userpw="pdf2image"
+                )
+                self.assertTrue("CreationDate" in info)
+        print(
+            "test_pdfinfo_locked_pdf_with_userpw_only: {} sec".format(time.time() - start_time)
+        )
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This is to make sure that the tests fail when a parameter was added to `convert_from_path` and not `convert_from_bytes` and vice-versa.
