### PR TITLE
Add test to ensure same parameter count

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -7,6 +7,7 @@ import unittest
 import time
 import shutil
 import subprocess
+from inspect import signature
 from subprocess import Popen, PIPE
 from tempfile import TemporaryDirectory
 from multiprocessing.dummy import Pool
@@ -1622,6 +1623,25 @@ class PDFConversionMethods(unittest.TestCase):
         print(
             "test_pdfinfo_locked_pdf_with_userpw_only: {} sec".format(time.time() - start_time)
         )
+
+    @profile
+    def test_convert_from_functions_same_number_of_parameters(self):
+        start_time = time.time()
+        self.assertEqual(
+            len(signature(convert_from_path).parameters),
+            len(signature(convert_from_bytes).parameters),
+        )
+        print("test_convert_from_functions_same_number_of_parameters: {} sec".format(time.time() - start_time))
+
+    @profile
+    def test_pdfinfo_functions_same_number_of_parameters(self):
+        start_time = time.time()
+        self.assertEqual(
+            len(signature(pdfinfo_from_path).parameters),
+            len(signature(pdfinfo_from_bytes).parameters),
+        )
+        print("test_pdfinfo_functions_same_number_of_parameters: {} sec".format(time.time() - start_time))
+    
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This is to make sure that the tests fail when a parameter was added to convert_from_path and not convert_from_bytes and vice-versa.