### PR TITLE
documentation about solution for docusign issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,4 @@ Here are the definitions:
 ## Limitations / known issues
 
 - A relatively big PDF will use up all your memory and cause the process to be killed (unless you use an output folder)
+- Sometimes fail read pdf signed using DocuSign, [Solution for DocuSign issue.](docs/installation.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -38,3 +38,17 @@ Poppler is the underlying project that does the magic in pdf2image. You can chec
 3. Move the extracted directory to the desired place on your system
 4. Add the `bin/` directory to your [PATH](https://www.architectryan.com/2018/03/17/add-to-the-path-on-windows-10/)
 5. Test that all went well by opening `cmd` and making sure that you can call `pdftoppm -h`
+
+## Solution for DocuSign issue
+If you have this [error](https://stackoverflow.com/questions/66636441/pdf2image-library-failing-to-read-pdf-signed-using-docusign):
+```bash
+pdf2image.exceptions.PDFPageCountError: Unable to get page count.
+Syntax Error: Gen inside xref table too large (bigger than INT_MAX)
+Syntax Error: Invalid XRef entry 3
+Syntax Error: Top-level pages object is wrong type (null)
+Command Line Error: Wrong page range given: the first page (1) can not be after the last page (0).
+```
+
+You are possibly using an old version of poppler. The solution is to update to the latest version. Similarly, if you are working with Docker (Debian 11 Image), maybe you can not update poppler because is not available. So, you have to use an image in ubuntu, install Python and then what you need.
+
+More details [here](https://github.com/Belval/pdf2image/issues/234).


### PR DESCRIPTION
## Documentation description
Reference [Wrong page range given: the first page (1) can not be after the last page (0)](https://github.com/Belval/pdf2image/issues/234) issue. But now is documented with the error and the solution.

First I add into the know issues list and then in `installation.md` I explain the solution.