### PR TITLE
Remove posix import

### DIFF
--- a/pdf2image/pdf2image.py
+++ b/pdf2image/pdf2image.py
@@ -5,7 +5,6 @@
 
 import os
 import platform
-import posix
 import tempfile
 import types
 import shutil
@@ -635,8 +634,9 @@ def pdfinfo_from_bytes(
             temp_filename,
             userpw=userpw,
             ownerpw=ownerpw,
-            rawdates=rawdates,
             poppler_path=poppler_path,
+            rawdates=rawdates,
+            timeout=timeout,
         )
     finally:
         os.close(fh)


### PR DESCRIPTION
Fixes: #249 

Unused imported was added in 1.16.1. Also need to pull the release and remove the version from PyPI.

Will need to investigate why the CI didn't raise and issue.