### PR TITLE
Fixed the issue: when the `single_file` is `True` and the `thread_count` is greater than 1, the `thread_output_file = next(output_file)` will fail.

### DIFF
--- a/pdf2image/pdf2image.py
+++ b/pdf2image/pdf2image.py
@@ -156,6 +156,7 @@ def convert_from_path(
     ):
         if single_file:
             output_file = iter([output_file])
+            thread_count = 1
         else:
             output_file = counter_generator(output_file)
 


### PR DESCRIPTION
Fixed the issue: when the `single_file` is `True` and the `thread_count` is greater than 1, the `thread_output_file = next(output_file)` will fail.