### PR TITLE
Add support for WebP image format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,9 @@ ENV/
 
 # Ignore my vscode config
 .vscode/
+
+# Ignore MacOS thumbnails
+.DS_Store
+
+# Ignore PyCharm files
+.idea

--- a/pdf2image/pdf2image.py
+++ b/pdf2image/pdf2image.py
@@ -21,6 +21,7 @@ from pdf2image.parsers import (
     parse_buffer_to_ppm,
     parse_buffer_to_jpeg,
     parse_buffer_to_png,
+    parse_buffer_to_webp
 )
 
 from pdf2image.exceptions import (
@@ -464,14 +465,16 @@ def _parse_format(fmt: str, grayscale: bool = False) -> Tuple[str, str, Callable
         fmt = fmt[1:]
     if fmt in ("jpeg", "jpg"):
         return "jpeg", "jpg", parse_buffer_to_jpeg, False
-    if fmt == "png":
+    elif fmt == "png":
         return "png", "png", parse_buffer_to_png, False
-    if fmt in ("tif", "tiff"):
-        return "tiff", "tif", None, True
-    if fmt == "ppm" and grayscale:
+    elif fmt in ("tif", "tiff"):
+        return "tiff", "tif", lambda _: None, True
+    elif fmt == "ppm" and grayscale:
         return "pgm", "pgm", parse_buffer_to_pgm, False
-    # Unable to parse the format so we'll use the default
-    return "ppm", "ppm", parse_buffer_to_ppm, False
+    elif fmt == "webp":
+        return "png", "webp", parse_buffer_to_webp, False
+    else:  # Unable to parse the format, so we'll use the default
+        return "ppm", "ppm", parse_buffer_to_ppm, False
 
 
 def _parse_jpegopt(jpegopt: Dict) -> str:

--- a/tests.py
+++ b/tests.py
@@ -2,7 +2,6 @@ import os
 import sys
 import errno
 import pathlib
-import tempfile
 import unittest
 import time
 import shutil
@@ -467,7 +466,7 @@ class PDFConversionMethods(unittest.TestCase):
             images_from_bytes = convert_from_bytes(pdf_file.read(), fmt="jpg")
             self.assertTrue(images_from_bytes[0].format == "JPEG")
         print(
-            "test_conversion_to_jpeg_from_bytes_14: {} sec".format(
+            "test_conversion_to_jpeg_from_bytes: {} sec".format(
                 (time.time() - start_time) / 14.0
             )
         )
@@ -483,7 +482,7 @@ class PDFConversionMethods(unittest.TestCase):
             self.assertTrue(images_from_path[0].format == "JPEG")
             [im.close() for im in images_from_path]
         print(
-            "test_conversion_to_jpeg_from_path_using_dir_14: {} sec".format(
+            "test_conversion_to_jpeg_from_path_using_dir: {} sec".format(
                 (time.time() - start_time) / 14.0
             )
         )
@@ -498,7 +497,7 @@ class PDFConversionMethods(unittest.TestCase):
             images_from_bytes = convert_from_bytes(pdf_file.read(), fmt="png")
             self.assertTrue(images_from_bytes[0].format == "PNG")
         print(
-            "test_conversion_to_png_from_bytes_14: {} sec".format(
+            "test_conversion_to_png_from_bytes: {} sec".format(
                 (time.time() - start_time) / 14.0
             )
         )
@@ -514,7 +513,38 @@ class PDFConversionMethods(unittest.TestCase):
             self.assertTrue(images_from_path[0].format == "PNG")
             [im.close() for im in images_from_path]
         print(
-            "test_conversion_to_png_from_path_using_dir_14: {} sec".format(
+            "test_conversion_to_png_from_path_using_dir: {} sec".format(
+                (time.time() - start_time) / 14.0
+            )
+        )
+
+    ## Test output as webp
+
+    @profile
+    @unittest.skipIf(not POPPLER_INSTALLED, "Poppler is not installed!")
+    def test_conversion_to_webp_from_bytes(self):
+        start_time = time.time()
+        with open("./tests/test.pdf", "rb") as pdf_file:
+            images_from_bytes = convert_from_bytes(pdf_file.read(), fmt="webp")
+            self.assertTrue(images_from_bytes[0].format == "WEBP")
+        print(
+            "test_conversion_to_webp_from_bytes: {} sec".format(
+                (time.time() - start_time) / 14.0
+            )
+        )
+
+    @profile
+    @unittest.skipIf(not POPPLER_INSTALLED, "Poppler is not installed!")
+    def test_conversion_to_webp_from_path_using_dir(self):
+        start_time = time.time()
+        with TemporaryDirectory() as path:
+            images_from_path = convert_from_path(
+                "./tests/test.pdf", output_folder=path, fmt="webp"
+            )
+            self.assertTrue(images_from_path[0].format == "WEBP")
+            [im.close() for im in images_from_path]
+        print(
+            "test_conversion_to_webp_from_path_using_dir: {} sec".format(
                 (time.time() - start_time) / 14.0
             )
         )


### PR DESCRIPTION
WebP is a modern, open source image format created by Google which boasts a lot of [advantages](https://developers.google.com/speed/webp) over jpeg and png. This PR adds support to write webp files from within pdf2image library by using Pillow's built in support for webp image format. This PR also rectifies some of the test names which weren't correct.