### PR TITLE
optional padding and sep

### DIFF
--- a/pdf2image/generators.py
+++ b/pdf2image/generators.py
@@ -42,5 +42,8 @@ def counter_generator(prefix="", suffix="", padding_goal=4):
     """Returns a joined prefix, iteration number, and suffix"""
     i = 0
     while True:
-        i += 1
-        yield str(prefix) + str(i).zfill(padding_goal) + str(suffix)
+        if padding_goal<1:
+            yield str(prefix) + str(suffix)
+        else:
+            i += 1
+            yield str(prefix) + str(i).zfill(padding_goal) + str(suffix)

--- a/pdf2image/pdf2image.py
+++ b/pdf2image/pdf2image.py
@@ -50,6 +50,8 @@ def convert_from_path(
     transparent: bool = False,
     single_file: bool = False,
     output_file: Any = uuid_generator(),
+    padding_goal: int = 4,
+    sep: str = "-",
     poppler_path: Union[str, PurePath] = None,
     grayscale: bool = False,
     size: Union[Tuple, int] = None,
@@ -90,6 +92,10 @@ def convert_from_path(
     :type single_file: bool, optional
     :param output_file: What is the output filename or generator, defaults to uuid_generator()
     :type output_file: Any, optional
+    :param padding_goal: Number of digits to pad after the given output_file, defaults to 4
+    :type padding_goal: int, optional
+    :param sep: Single character separator between name and page number, default -
+    :type sep: str, optional
     :param poppler_path: Path to look for poppler binaries, defaults to None
     :type poppler_path: Union[str, PurePath], optional
     :param grayscale: Output grayscale image(s), defaults to False
@@ -110,6 +116,10 @@ def convert_from_path(
     :return: A list of Pillow images, one for each page between first_page and last_page
     :rtype: List[Image.Image]
     """
+
+    #don't let the user abuse the padding
+    if padding_goal>4:
+        padding_goal=4
 
     if use_pdftocairo and fmt == "ppm":
         fmt = "png"
@@ -157,7 +167,7 @@ def convert_from_path(
         if single_file:
             output_file = iter([output_file])
         else:
-            output_file = counter_generator(output_file)
+            output_file = counter_generator(output_file, "", padding_goal)
 
     if thread_count < 1:
         thread_count = 1
@@ -200,6 +210,7 @@ def convert_from_path(
                 parsed_fmt,
                 jpegopt,
                 thread_output_file,
+                sep,
                 userpw,
                 ownerpw,
                 use_cropbox,
@@ -392,6 +403,7 @@ def _build_command(
     fmt: str,
     jpegopt: Dict,
     output_file: str,
+    sep: str,
     userpw: str,
     ownerpw: str,
     use_cropbox: bool,
@@ -436,6 +448,8 @@ def _build_command(
 
     if grayscale:
         args.append("-gray")
+
+    args.extend(["-sep", sep])
 
     if size is None:
         pass


### PR DESCRIPTION
Extended to address https://stackoverflow.com/questions/75032116/pdf2image-how-to-remove-the-0001-in-jpg-file-names

includes pdftoppm option "-sep"

I wanted to remove the padding given to file names, as well as the "-" separator. The code changes let users have an option "-sep" arg that rolls into the pdftoppm args, and users can define the amount of padding